### PR TITLE
fixed a small mistake. Put || operator instead of &&

### DIFF
--- a/src/main/java/com/bulletphysics/collision/broadphase/HashedOverlappingPairCache.java
+++ b/src/main/java/com/bulletphysics/collision/broadphase/HashedOverlappingPairCache.java
@@ -174,7 +174,7 @@ public class HashedOverlappingPairCache extends OverlappingPairCache {
         }
 
         boolean collides = (proxy0.collisionFilterGroup & proxy1.collisionFilterMask) != 0;
-        collides = collides && (proxy1.collisionFilterGroup & proxy0.collisionFilterMask) != 0;
+        collides = collides || (proxy1.collisionFilterGroup & proxy0.collisionFilterMask) != 0;
 
         return collides;
     }


### PR DESCRIPTION
So that the collisions will occur even if one of the entity has the collisionGroup of other entity in their collidesWith group.